### PR TITLE
[#50193251] Used '?:' modifier to remove dummy parameters from the step definitions.

### DIFF
--- a/features/forward_ipn.feature
+++ b/features/forward_ipn.feature
@@ -6,12 +6,12 @@ Feature: forward an IPN from PayPal to a development machine
   Scenario: PayPal sandbox sends IPN to common server
     When the sandbox sends an IPN for the recurring payment to the server
     Then the server puts the IPN into the queue
-    And it sends a successful response back to the sandbox
+    And it returns a successful response back to the sandbox
 
   Scenario: Server sends IPN to specific developer computer
     Given the server has an IPN in the queue
     When it sends an IPN to the specified computer
-    Then the computer sends a successful response back to the server
+    Then the computer returns a successful response back to the server
     And the server purges the IPN from the queue
 
   Scenario: Developer computer is offline and the server bangs on it until it comes back
@@ -19,7 +19,7 @@ Feature: forward an IPN from PayPal to a development machine
     Then it receives no response
     When the server waits 5 seconds
     And it resends the IPN to the recalcitrant computer
-    Then the computer sends a successful response back to the server
+    Then the computer returns a successful response back to the server
     And the server purges the IPN from the queue
 
 # The developer computer doesn't have a notion of being online or not

--- a/features/step_definitions/paypal_ipn_proxy_steps.rb
+++ b/features/step_definitions/paypal_ipn_proxy_steps.rb
@@ -18,8 +18,7 @@ def configure(source_blob, destination_blob)
 end
 
 # When the server sends an ipn to my computer
-When(/^(the|a|it) (.*?)sends (an|the) IPN( for the recurring payment|) to (my|the|an|a|)\s+(specified |recalcitrant |)(\w+)$/) do |dummy, source_blob, dummy5, payment, dummy2, dummy3, destination_blob|
-
+When(/^(?:the|a|it) (.*?)sends (?:an|the) IPN(?: for the recurring payment|) to (?:my|the|an|a|)\s+(?:specified |recalcitrant |)(\w+)$/) do |source_blob, destination_blob|
   configure(source_blob, destination_blob)
 end
 
@@ -27,15 +26,15 @@ Then(/^the server notifies the developers about the unknown PayPal sandbox$/) do
   pending # express the regexp above with the code you wish you had
 end
 
-When(/^(the server|it) sends (an|the) IPN repeatedly for (\d+)( more|) days.+$/) do |dummy, dummy2, dummy3, days|
+When(/^(?:the server|it) sends (?:an|the) IPN repeatedly for (\d+)(?: more|) days.+$/) do |days|
   pending # express the regexp above with the code you wish you had
 end
 
-Then(/^(the server|it) (notifies|has notified)\s+(.+?)(\d+) days$/) do |dummy, dummy2, preamble,days|
+Then(/^(?:the server|it) (?:notifies|has notified)\s+(.+?)(\d+) days$/) do |preamble, days|
   pending # express the regexp above with the code you wish you had
 end
 
-Given(/^the server (has|puts|purges) .+? IPN (in|into|from) the queue$/) do |action, dummy|
+Given(/^the server (has|puts|purges) .+? IPN (?:in|into|from) the queue$/) do |action|
   pending # express the regexp above with the code you wish you had
 end
 
@@ -43,6 +42,6 @@ Then(/.+?returns a successful response back to the (server|sandbox)$/) do |desti
   @source.send_ipn.should == "a response"
 end
 
-When(/^the server waits (\d+) seconds$/) do |arg1|
+When(/^the server waits (\d+) seconds$/) do |seconds|
   pending # express the regexp above with the code you wish you had
 end


### PR DESCRIPTION
Also cleaned up some feature lines by changing 'sends...response' to
'return...response'
