### PR TITLE
Fix router start and stop test tests to work

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -49,7 +49,7 @@ class ServerRack < Sinatra::Base
   end
 
   get '/launch' do
-    url = 'http://localhost:7810/server/recieve'
+    url = 'http://localhost:7810/server/receive'
     sample_ipn = <<EOF
 mc_gross=19.95&protection_eligibility=Eligible&address_status=confirmed&pay\
 er_id=LPLWNMTBWMFAY&tax=0.00&address_street=1+Main+St&payment_date=20%3A12%\
@@ -68,7 +68,7 @@ EOF
     RestClient.post url, sample_ipn
   end
 
-  post '/server/recieve' do
+  post '/server/receive' do
     url = 'http://localhost:6810/back/to/paypal'
     ipn = request.body.read
     ipn = "_notify-validate&" + ipn

--- a/config.ru
+++ b/config.ru
@@ -20,7 +20,7 @@ class ServerRack < Sinatra::Base
 
   get '/ipn-response' do
     comp_id = request.body.read
-    puts comp_id# make sure request.body.read works
+    puts comp_id # make sure request.body.read works
     @server_client.send_response_to_computer(comp_id)
   end
 
@@ -29,7 +29,7 @@ class ServerRack < Sinatra::Base
     unless ipn == 'VERIFIED' || ipn == 'INVALID'
       @server_client.receive_ipn(ipn)
       response = @server_client.ipn_response(ipn)
-      url = 'https://www.sandbox.paypal.com/cgi-bin/webscr'
+      url      = 'https://www.sandbox.paypal.com/cgi-bin/webscr'
       RestClient.post url, response
     end
   end
@@ -49,7 +49,7 @@ class ServerRack < Sinatra::Base
   end
 
   get '/launch' do
-    url = 'http://localhost:7810/server/receive'
+    url        = 'http://localhost:7810/server/receive'
     sample_ipn = <<EOF
 mc_gross=19.95&protection_eligibility=Eligible&address_status=confirmed&pay\
 er_id=LPLWNMTBWMFAY&tax=0.00&address_street=1+Main+St&payment_date=20%3A12%\
@@ -76,8 +76,8 @@ EOF
   end
 
   post '/back/to/paypal' do
-    ipn = request.body.read
-    url = 'http://superbox.hedgeye.com:8810/payments/ipn'
+    ipn        = request.body.read
+    url        = 'http://superbox.hedgeye.com:8810/payments/ipn'
     #url = 'http://localhost:5810/message'
     sample_ipn = <<EOF
 mc_gross=19.95&protection_eligibility=Eligible&address_status=confirmed&pay\

--- a/lib/development_computer.rb
+++ b/lib/development_computer.rb
@@ -1,5 +1,5 @@
 
-class Cms
+class DevelopmentComputer
   SAMPLE_IPN = <<EOF
 mc_gross=19.95&protection_eligibility=Eligible&address_status=confirmed&pay\
 er_id=LPLWNMTBWMFAY&tax=0.00&address_street=1+Main+St&payment_date=20%3A12%\

--- a/lib/router.rb
+++ b/lib/router.rb
@@ -1,6 +1,9 @@
 require_relative 'poller'
 class Router
 
+  TEST_ON = 'on'
+  TEST_OFF = 'off'
+
   def initialize(target)
     @target  = target
     @server_url = load_server_url
@@ -23,11 +26,11 @@ class Router
   end
 
   def test_mode_on
-    set_test_mode('on')
+    set_test_mode(TEST_ON)
   end
 
   def test_mode_off
-    set_test_mode('off')
+    set_test_mode(TEST_OFF)
   end
 
   #from: http://claudiofloreani.blogspot.com/2011/10/ruby-how-to-get-my-private-and-public.html

--- a/lib/router.rb
+++ b/lib/router.rb
@@ -3,6 +3,7 @@ class Router
 
   def initialize(target)
     @target  = target
+    @server_url = load_server_url
   end
 
   def forward_ipn(ipn)
@@ -21,21 +22,23 @@ class Router
     @target.send_ipn(ipn)
   end
 
-  def load_server_url
-    url = YAML::load_file(File.expand_path('../../config/config.yml', __FILE__))
-  end
-
   def test_mode_on
-    RestClient.post load_server_url, my_ip_address
+    RestClient.post(@server_url, my_ip_address)
   end
 
   def test_mode_off
-    RestClient.post load_server_url, my_ip_address
+    RestClient.post(@server_url, my_ip_address)
   end
 
   #from: http://claudiofloreani.blogspot.com/2011/10/ruby-how-to-get-my-private-and-public.html
   def my_ip_address
     Socket.ip_address_list.detect { |intf| intf.ipv4_private? }.ip_address
+  end
+
+  private
+
+  def load_server_url
+    url = YAML::load_file(File.expand_path('../../config/config.yml', __FILE__))
   end
 
 end

--- a/lib/router.rb
+++ b/lib/router.rb
@@ -8,7 +8,7 @@ class Router
 
 
   def forward_ipn(ipn)
-      if(ipn == "VERIFIED")
+      if(ipn == 'VERIFIED')
          send_verified
       else
         send_ipn(ipn)
@@ -24,7 +24,7 @@ class Router
   end
 
   def load_server_url
-    url = YAML::load_file(File.expand_path("../../config/router.yml", __FILE__))
+    url = YAML::load_file(File.expand_path('../../config/config.yml', __FILE__))
   end
 
   def test_mode_on

--- a/lib/router.rb
+++ b/lib/router.rb
@@ -23,11 +23,13 @@ class Router
   end
 
   def test_mode_on
-    RestClient.post(@server_url, my_ip_address)
+    RestClient.post(@server_url, { params: { my_ip: my_ip_address, test_mode: 'on'
+    } })
   end
 
   def test_mode_off
-    RestClient.post(@server_url, my_ip_address)
+    RestClient.post(@server_url, { params: { my_ip: my_ip_address, test_mode: 'off'
+    } })
   end
 
   #from: http://claudiofloreani.blogspot.com/2011/10/ruby-how-to-get-my-private-and-public.html

--- a/lib/router.rb
+++ b/lib/router.rb
@@ -3,9 +3,7 @@ class Router
 
   def initialize(target)
     @target  = target
-    @killing = false
   end
-
 
   def forward_ipn(ipn)
     if (ipn == 'VERIFIED')

--- a/lib/router.rb
+++ b/lib/router.rb
@@ -2,25 +2,25 @@ require_relative 'poller'
 class Router
 
   def initialize(target)
-    @target = target
+    @target  = target
     @killing = false
   end
 
 
   def forward_ipn(ipn)
-      if(ipn == 'VERIFIED')
-         send_verified
-      else
-        send_ipn(ipn)
-      end
+    if (ipn == 'VERIFIED')
+      send_verified
+    else
+      send_ipn(ipn)
     end
+  end
 
-  def send_verified#same functionality as send_verification
+  def send_verified #same functionality as send_verification
     @target.verified
   end
 
   def send_ipn(ipn)
-   @target.send_ipn(ipn)
+    @target.send_ipn(ipn)
   end
 
   def load_server_url
@@ -37,7 +37,7 @@ class Router
 
   #from: http://claudiofloreani.blogspot.com/2011/10/ruby-how-to-get-my-private-and-public.html
   def my_ip_address
-    Socket.ip_address_list.detect{|intf| intf.ipv4_private?}.ip_address
+    Socket.ip_address_list.detect { |intf| intf.ipv4_private? }.ip_address
   end
 
 end

--- a/lib/router.rb
+++ b/lib/router.rb
@@ -23,13 +23,11 @@ class Router
   end
 
   def test_mode_on
-    RestClient.post(@server_url, { params: { my_ip: my_ip_address, test_mode: 'on'
-    } })
+    set_test_mode('on')
   end
 
   def test_mode_off
-    RestClient.post(@server_url, { params: { my_ip: my_ip_address, test_mode: 'off'
-    } })
+    set_test_mode('off')
   end
 
   #from: http://claudiofloreani.blogspot.com/2011/10/ruby-how-to-get-my-private-and-public.html
@@ -41,6 +39,11 @@ class Router
 
   def load_server_url
     url = YAML::load_file(File.expand_path('../../config/config.yml', __FILE__))
+  end
+
+  def set_test_mode(mode)
+    RestClient.post(@server_url, { params: { my_ip: my_ip_address, test_mode: mode
+    } })
   end
 
 end

--- a/lib/router.rb
+++ b/lib/router.rb
@@ -1,10 +1,9 @@
 require_relative 'poller'
 class Router
 
-  def initialize(target, server_client)
+  def initialize(target)
     @target = target
     @killing = false
-    @server_client = server_client
   end
 
 
@@ -33,12 +32,11 @@ class Router
   end
 
   def test_mode_off
-    url = 'http://superbox.hedgeye.com:8810/test/'
-    message = ip_address
-    @server_client.post @url, message
+    RestClient.post load_server_url, my_ip_address
   end
 
-  def my_ip_address #from: http://claudiofloreani.blogspot.com/2011/10/ruby-how-to-get-my-private-and-public.html
+  #from: http://claudiofloreani.blogspot.com/2011/10/ruby-how-to-get-my-private-and-public.html
+  def my_ip_address
     Socket.ip_address_list.detect{|intf| intf.ipv4_private?}.ip_address
   end
 

--- a/spec/router_spec.rb
+++ b/spec/router_spec.rb
@@ -89,7 +89,9 @@ ross=19.95&shipping=0.00
 EOF
       end
 
-
+      it 'automatically identifies the developer computer' do
+        @router.my_ip_address.should =~ /\d+\.\d+\.\d+\.\d+/
+      end
 
       # TODO: @cms and @router are going to have to be tied together
       it 'processes an IPN' do

--- a/spec/router_spec.rb
+++ b/spec/router_spec.rb
@@ -23,7 +23,7 @@ describe Router do
       end
 
       it 'has started' do
-        expected_rest_client_message('on')
+        expected_rest_client_message(Router::TEST_ON)
         @router.test_mode_on
       end
 
@@ -34,7 +34,7 @@ describe Router do
       #end
 
       it 'has stopped' do
-        expected_rest_client_message('off')
+        expected_rest_client_message(Router::TEST_OFF)
         @router.test_mode_off
       end
 

--- a/spec/router_spec.rb
+++ b/spec/router_spec.rb
@@ -1,5 +1,4 @@
-require 'rest-client'
-require_relative 'spec_helper'
+require 'rspec'
 require_relative '../lib/router'
 require_relative '../lib/poller'
 require_relative '../lib/server'

--- a/spec/router_spec.rb
+++ b/spec/router_spec.rb
@@ -5,12 +5,15 @@ require_relative '../lib/server'
 
 describe Router do
 
+  before(:each) do
+    @target = mock('target')
+  end
+
   context 'when created' do
 
     it 'tells the server that test mode has started' do
       server_url = YAML::load_file(File.expand_path('../../config/config.yml', __FILE__))
-      target = mock('target')
-      router = Router.new(target)
+      router = Router.new(@target)
       RestClient.should_receive(:post).with(server_url, router.my_ip_address)
       router.test_mode_on
     end
@@ -20,7 +23,6 @@ describe Router do
   context 'exists' do
 
     before(:each) do
-      @target = mock('target')
       @router = Router.new(@target)
       @poll = Poller.new(@router, 'http://superbox.hedgeye.com:8810/test')
     end

--- a/spec/router_spec.rb
+++ b/spec/router_spec.rb
@@ -14,24 +14,30 @@ describe Router do
 
   context 'interactions with server' do
 
-    it 'tells the server that test mode has started' do
-      RestClient.should_receive(:post).with(@server_url, { params: { my_ip:     @router.my_ip_address,
-                                                                     test_mode: 'on'
-      } })
-      @router.test_mode_on
-    end
+    context 'test mode' do
 
-    # FIXME or get rid of me
-    #it 'stops polling the server' do
-    #  @router.test_mode_on
-    #  @router.test_mode_off
-    #end
+      def expected_rest_client_message(mode)
+        RestClient.should_receive(:post).with(@server_url, { params: { my_ip:     @router.my_ip_address,
+                                                                       test_mode: mode
+        } })
+      end
 
-    it 'tells the server that test mode has finished' do
-      RestClient.should_receive(:post).with(@server_url, { params: { my_ip:     @router.my_ip_address,
-                                                                     test_mode: 'off'
-      } })
-      @router.test_mode_off
+      it 'has started' do
+        expected_rest_client_message('on')
+        @router.test_mode_on
+      end
+
+      # FIXME or get rid of me
+      #it 'stops polling the server' do
+      #  @router.test_mode_on
+      #  @router.test_mode_off
+      #end
+
+      it 'has stopped' do
+        expected_rest_client_message('off')
+        @router.test_mode_off
+      end
+
     end
 
     context 'polling retrieves an IPN' do

--- a/spec/router_spec.rb
+++ b/spec/router_spec.rb
@@ -8,9 +8,9 @@ describe Router do
   context 'when created' do
 
     it 'tells the server that test mode has started' do
-      server_url = YAML::load_file(File.expand_path("../../config/router.yml", __FILE__))
+      server_url = YAML::load_file(File.expand_path('../../config/config.yml', __FILE__))
       target = mock('target')
-      router = Router.new(target, @server_client)
+      router = Router.new(target)
       RestClient.should_receive(:post).with(server_url, router.my_ip_address)
       router.test_mode_on
     end
@@ -106,7 +106,7 @@ EOF
         @target.should_receive(:verified)
         server = Server.new
         server.store_ipn_response('developer_one')
-        server.send_response_to_computer('developer_one').should == "VERIFIED"
+        server.send_response_to_computer('developer_one').should == 'VERIFIED'
         @router.forward_ipn(server.send_response_to_computer('developer_one'))
       end
 

--- a/spec/router_spec.rb
+++ b/spec/router_spec.rb
@@ -13,7 +13,7 @@ describe Router do
 
     it 'tells the server that test mode has started' do
       server_url = YAML::load_file(File.expand_path('../../config/config.yml', __FILE__))
-      router = Router.new(@target)
+      router     = Router.new(@target)
       RestClient.should_receive(:post).with(server_url, router.my_ip_address)
       router.test_mode_on
     end
@@ -24,7 +24,7 @@ describe Router do
 
     before(:each) do
       @router = Router.new(@target)
-      @poll = Poller.new(@router, 'http://superbox.hedgeye.com:8810/test')
+      @poll   = Poller.new(@router, 'http://superbox.hedgeye.com:8810/test')
     end
 
     context 'when destroying' do

--- a/spec/router_spec.rb
+++ b/spec/router_spec.rb
@@ -48,12 +48,12 @@ describe Router do
 
     context 'polling retrieves an IPN' do
 
-      it 'initiates a protocol to send the IPN to cms'
-      #unsure of what url the http protocol will use to interact with cms
+      it 'initiates a protocol to send the IPN to the development computer'
+      #unsure of what url the http protocol will use to interact with development computer
 
     end
 
-    context 'handshake between router and CMS' do
+    context 'handshake between router and development computer' do
 
       def create_an_ipn_somehow
         sample_ipn = <<EOF
@@ -95,7 +95,7 @@ EOF
         @router.my_ip_address.should =~ /\d+\.\d+\.\d+\.\d+/
       end
 
-      # TODO: @cms and @router are going to have to be tied together
+      # TODO: development computer and @router are going to have to be tied together
       it 'processes an IPN' do
         ipn          = create_an_ipn_somehow
         ipn_response = create_ipn_response_somehow

--- a/spec/router_spec.rb
+++ b/spec/router_spec.rb
@@ -1,4 +1,5 @@
-require 'rspec'
+require 'rest-client'
+require_relative 'spec_helper'
 require_relative '../lib/router'
 require_relative '../lib/poller'
 require_relative '../lib/server'
@@ -6,57 +7,47 @@ require_relative '../lib/server'
 describe Router do
 
   before(:each) do
-    @target = mock('target')
+    @target     = mock('target')
+    @router     = Router.new(@target)
+    @server_url = YAML::load_file(File.expand_path('../../config/config.yml', __FILE__))
+    @poll       = Poller.new(@router, @server_url)
   end
 
-  context 'when created' do
+  context 'interactions with server' do
 
     it 'tells the server that test mode has started' do
-      server_url = YAML::load_file(File.expand_path('../../config/config.yml', __FILE__))
-      router     = Router.new(@target)
-      RestClient.should_receive(:post).with(server_url, router.my_ip_address)
-      router.test_mode_on
+      RestClient.should_receive(:post).with(@server_url, { params: { my_ip:     @router.my_ip_address,
+                                                                     test_mode: 'on'
+      } })
+      @router.test_mode_on
     end
 
-  end
-
-  context 'exists' do
-
-    before(:each) do
-      @router = Router.new(@target)
-      @poll   = Poller.new(@router, 'http://superbox.hedgeye.com:8810/test')
+    # FIXME or get rid of me
+    it 'stops polling the server' do
+      @router.test_mode_on
+      @router.test_mode_off
     end
 
-    context 'when destroying' do
-
-      it 'stops polling the server' do
-        router = Router.new
-        @router.test_mode_on
-        @router.test_mode_off
-        defined?(router).should be false
-      end
-
-      it 'tells the server that test mode has finished' do
-        #needs to be changed based on changes on line 9-14 which were made with Scott's help
-        server = Server.new
-        @router.test_mode_off
-        server.computer_testing('developer_one')
-        server.computer_online?('developer_one').should == false
-      end
-
+    it 'tells the server that test mode has finished' do
+      RestClient.should_receive(:post).with(@server_url, { params: { my_ip:     @router.my_ip_address,
+                                                                     test_mode: 'off'
+      } })
+      @router.test_mode_off
     end
 
     context 'polling retrieves an IPN' do
 
       it 'initiates a protocol to send the IPN to the development computer'
-      #unsure of what url the http protocol will use to interact with development computer
+      RestClient.should_receive(:post).with(@server_url, @router.my_ip_address)
 
     end
 
-    context 'handshake between router and development computer' do
+  end
 
-      def create_an_ipn_somehow
-        sample_ipn = <<EOF
+  context 'handshake between router and development computer' do
+
+    def create_an_ipn_somehow
+      sample_ipn = <<EOF
 mc_gross=19.95&protection_eligibility=Eligible&address_status=confirmed&pay\
 er_id=LPLWNMTBWMFAY&tax=0.00&address_street=1+Main+St&payment_date=20%3A12%\
 3A59+Jan+13%2C+2009+PST&payment_status=Completed&charset=windows-\
@@ -71,10 +62,10 @@ OfCXbDm2hu0ZELryHFjY-Vb7PAUvS6nMXgysbElEn9v-\
 e_country=US&test_ipn=1&handling_amount=0.00&transaction_subject=&payment_g\
 ross=19.95&shipping=0.00
 EOF
-      end
+    end
 
-      def create_ipn_response_somehow
-        verified_ipn = <<EOF
+    def create_ipn_response_somehow
+      verified_ipn = <<EOF
 cmd=_notify-validate&mc_gross=19.95&protection_eligibility=Eligible&address_status=confirmed&pay\
 er_id=LPLWNMTBWMFAY&tax=0.00&address_street=1+Main+St&payment_date=20%3A12%\
 3A59+Jan+13%2C+2009+PST&payment_status=Completed&charset=windows-\
@@ -89,29 +80,27 @@ OfCXbDm2hu0ZELryHFjY-Vb7PAUvS6nMXgysbElEn9v-\
 e_country=US&test_ipn=1&handling_amount=0.00&transaction_subject=&payment_g\
 ross=19.95&shipping=0.00
 EOF
-      end
+    end
 
-      it 'automatically identifies the developer computer' do
-        @router.my_ip_address.should =~ /\d+\.\d+\.\d+\.\d+/
-      end
+    it 'automatically identifies the developer computer' do
+      @router.my_ip_address.should =~ /\d+\.\d+\.\d+\.\d+/
+    end
 
-      # TODO: development computer and @router are going to have to be tied together
-      it 'processes an IPN' do
-        ipn          = create_an_ipn_somehow
-        ipn_response = create_ipn_response_somehow
-        @target.stub!(:send_ipn).with(ipn).and_return(ipn_response)
-        @router.forward_ipn(ipn)
+    # TODO: development computer and @router are going to have to be tied together
+    it 'processes an IPN' do
+      ipn          = create_an_ipn_somehow
+      ipn_response = create_ipn_response_somehow
+      @target.stub!(:send_ipn).with(ipn).and_return(ipn_response)
+      @router.forward_ipn(ipn)
 
-      end
+    end
 
-      it 'send a verification message' do
-        @target.should_receive(:verified)
-        server = Server.new
-        server.store_ipn_response('developer_one')
-        server.send_response_to_computer('developer_one').should == 'VERIFIED'
-        @router.forward_ipn(server.send_response_to_computer('developer_one'))
-      end
-
+    it 'send a verification message' do
+      @target.should_receive(:verified)
+      server = Server.new
+      server.store_ipn_response('developer_one')
+      server.send_response_to_computer('developer_one').should == 'VERIFIED'
+      @router.forward_ipn(server.send_response_to_computer('developer_one'))
     end
 
   end

--- a/spec/router_spec.rb
+++ b/spec/router_spec.rb
@@ -22,10 +22,10 @@ describe Router do
     end
 
     # FIXME or get rid of me
-    it 'stops polling the server' do
-      @router.test_mode_on
-      @router.test_mode_off
-    end
+    #it 'stops polling the server' do
+    #  @router.test_mode_on
+    #  @router.test_mode_off
+    #end
 
     it 'tells the server that test mode has finished' do
       RestClient.should_receive(:post).with(@server_url, { params: { my_ip:     @router.my_ip_address,
@@ -36,8 +36,9 @@ describe Router do
 
     context 'polling retrieves an IPN' do
 
-      it 'initiates a protocol to send the IPN to the development computer'
-      RestClient.should_receive(:post).with(@server_url, @router.my_ip_address)
+      it 'initiates a protocol to send the IPN to the development computer' do
+        RestClient.should_receive(:post).with(@server_url, @router.my_ip_address)
+      end
 
     end
 

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -33,7 +33,7 @@ describe Server do
 
   it 'records that it has received an IPN response from a specific CMS' do
     server = Server.new
-    cms = Cms.new
+    cms = DevelopmentComputer.new
     ipn_response = cms.send_ipn_response
     server.receive_ipn_response(ipn_response)
     paypal_id = server.paypal_id(ipn_response)
@@ -43,7 +43,7 @@ describe Server do
 
   it 'confirms a IPN response for a polling request from the router for that IPN response' do
     server = Server.new
-    cms = Cms.new
+    cms = DevelopmentComputer.new
     ipn_response = cms.send_ipn_response
     server.receive_ipn_response(ipn_response)
     paypal_id = server.paypal_id(ipn_response)

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -1,7 +1,7 @@
 require_relative 'spec_helper'
 require_relative '../lib/server'
 require_relative '../lib/sandbox'
-require_relative '../lib/cms'
+require_relative '../lib/development_computer'
 require_relative '../lib/computer'
 
 
@@ -31,10 +31,10 @@ describe Server do
       computer.ipn.should == nil
   end
 
-  it 'records that it has received an IPN response from a specific CMS' do
+  it 'records that it has received an IPN response from a specific development computer' do
     server = Server.new
-    cms = DevelopmentComputer.new
-    ipn_response = cms.send_ipn_response
+    computer = DevelopmentComputer.new
+    ipn_response = computer.send_ipn_response
     server.receive_ipn_response(ipn_response)
     paypal_id = server.paypal_id(ipn_response)
     computer_id = server.computer_id(paypal_id)
@@ -43,8 +43,8 @@ describe Server do
 
   it 'confirms a IPN response for a polling request from the router for that IPN response' do
     server = Server.new
-    cms = DevelopmentComputer.new
-    ipn_response = cms.send_ipn_response
+    computer = DevelopmentComputer.new
+    ipn_response = computer.send_ipn_response
     server.receive_ipn_response(ipn_response)
     paypal_id = server.paypal_id(ipn_response)
     computer_id = server.computer_id(paypal_id)


### PR DESCRIPTION
Found out why

``` ruby
RestClient.should_receive...
```

wasn't working; there was a stray command that wasn't inside of an `RSpec` phrase later on.

Did some refactoring; each refactoring is a separate commit with an explanation.
